### PR TITLE
[JENKINS-58605] <url> in pom.xml must not point to plugins.jenkins.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <description>
         This plugin provides access to Trilead without having to bundle Trilead in Jenkins core
     </description>
-    <url>https://plugins.jenkins.io/trilead-api</url>
+    <url>https://github.com/jenkinsci/trilead-api-plugin</url>
     <licenses>
         <license>
             <name>The MIT license</name>


### PR DESCRIPTION
see [JENKINS-58605](https://issues.jenkins-ci.org/browse/JENKINS-58605)