### PR TITLE
chore: bump trilead-ssh2 build-217-jenkins-19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>trilead-ssh2</artifactId>
-            <version>build-217-jenkins-16</version>
+            <version>build-217-jenkins-19</version>
         </dependency>
         <dependency>
             <groupId>org.kohsuke</groupId>


### PR DESCRIPTION
bump trilead-ssh2 module to build-217-jenkins-19