### PR TITLE
feat: Bump trileas-ssh2 to build-217-jenkins-25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>trilead-ssh2</artifactId>
-            <version>build-217-jenkins-23</version>
+            <version>build-217-jenkins-25</version>
         </dependency>
         <dependency>
             <groupId>org.kohsuke</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>trilead-ssh2</artifactId>
-            <version>build-217-jenkins-22</version>
+            <version>build-217-jenkins-23</version>
         </dependency>
         <dependency>
             <groupId>org.kohsuke</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <properties>
       <revision>1.0.9</revision>
       <changelist>-SNAPSHOT</changelist>
-      <jenkins.version>2.184</jenkins.version>
+      <jenkins.version>2.204</jenkins.version>
       <java.level>8</java.level>
     </properties>
 
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>trilead-ssh2</artifactId>
-            <version>build-217-jenkins-21</version>
+            <version>build-217-jenkins-22</version>
         </dependency>
         <dependency>
             <groupId>org.kohsuke</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.45</version>
+        <version>4.3</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,17 @@
         </pluginRepository>
     </pluginRepositories>
 
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>io.jenkins.tools.bom</groupId>
+          <artifactId>bom-2.204.x</artifactId>
+          <version>11</version>
+          <type>pom</type>
+          <scope>import</scope>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci</groupId>


### PR DESCRIPTION
Bump Trilead-ssh2 to build-217-jenkins-25 see https://github.com/jenkinsci/trilead-ssh2/releases/tag/trilead-ssh2-build-217-jenkins-25
Bump Jenkins core version to 2.204

