### PR TITLE
chore: use less CI resources

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,2 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
-buildPlugin()
+buildPlugin(platforms: ['linux'])


### PR DESCRIPTION
Compile only on Linux, this is a wrapper for a library that does not contain tests or anything else.
