### PR TITLE
fix: add gitHubRepo var

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,15 +41,16 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/trilead-api-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/trilead-api-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/trilead-api-plugin</url>
+        <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
         <tag>${scmTag}</tag>
   </scm>
 
     <properties>
       <revision>1.0.12</revision>
       <changelist>-SNAPSHOT</changelist>
+      <gitHubRepo>jenkinsci/trilead-api-plugin</gitHubRepo>
       <jenkins.version>2.204</jenkins.version>
       <java.level>8</java.level>
     </properties>


### PR DESCRIPTION
Update the incrementals configuration https://github.com/jenkinsci/incrementals-tools#enabling-incrementals-the-hard-way

>Also replace jenkinsci/your-repo occurrences in the scm section with a POM property named gitHubRepo. This will ensure that deployments from forked pull requests will give correct checkout information, used for example by plugin-compat-tester.



