### PR TITLE
feat: enable continuous delivery workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: /
+    schedule:
+      interval: "daily"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,1 @@
+_extends: .github

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,59 @@
+# Note: additional setup is required, see https://www.jenkins.io/redirect/continuous-delivery-of-plugins
+
+name: cd
+on:
+  workflow_dispatch:
+  check_run:
+    types:
+      - completed
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.verify-ci-status.outputs.result == 'success' && steps.interesting-categories.outputs.interesting == 'true' }}
+    steps:
+      - name: Verify CI status
+        uses: jenkins-infra/verify-ci-status-action@v1.2.0
+        id: verify-ci-status
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          output_result: true
+
+      - name: Release Drafter
+        uses: release-drafter/release-drafter@v5
+        if: steps.verify-ci-status.outputs.result == 'success'
+        with:
+          name: next
+          tag: next
+          version: next
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check interesting categories
+        uses: jenkins-infra/interesting-category-action@v1.0.0
+        id: interesting-categories
+        if: steps.verify-ci-status.outputs.result == 'success'
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [validate]
+    if: needs.validate.outputs.should_release == 'true'
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 8
+      - name: Release
+        uses: jenkins-infra/jenkins-maven-cd-action@v1.2.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
+-Dchangelist.format=%d.v%s

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>trilead-api</artifactId>
-    <version>${revision}${changelist}</version>
+    <version>${revision}.${changelist}</version>
     <packaging>hpi</packaging>
 
 
@@ -48,11 +48,11 @@
   </scm>
 
     <properties>
-      <revision>1.0.14</revision>
-      <changelist>-SNAPSHOT</changelist>
-      <gitHubRepo>jenkinsci/trilead-api-plugin</gitHubRepo>
-      <jenkins.version>2.204</jenkins.version>
-      <java.level>8</java.level>
+        <revision>1</revision>
+        <changelist>999999-SNAPSHOT</changelist>
+        <gitHubRepo>jenkinsci/trilead-api-plugin</gitHubRepo>
+        <jenkins.version>2.204</jenkins.version>
+        <java.level>8</java.level>
     </properties>
 
     <repositories>


### PR DESCRIPTION
[JEP-229: Continuous Delivery of Jenkins Components and Plugins](https://github.com/jenkinsci/jep/blob/master/jep/229/README.adoc)
[Setting up automated plugin release](https://www.jenkins.io/doc/developer/publishing/releasing-cd/)


Depends on https://github.com/jenkins-infra/repository-permissions-updater/pull/2482

