### PR TITLE
Revert "chore(deps): bump trilead-ssh2 from build-217-jenkins-27 to build-217-jenkins-223.v546f979619d4"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>trilead-ssh2</artifactId>
-            <version>build-217-jenkins-223.v546f979619d4</version>
+            <version>build-217-jenkins-27</version>
         </dependency>
         <dependency>
             <groupId>org.kohsuke</groupId>


### PR DESCRIPTION
see [JENKINS-69018](https://issues.jenkins.io/browse/JENKINS-69018)

Reverts jenkinsci/trilead-api-plugin#51