### PR TITLE
BEE-14964/Upgrade-protobuf-to-fix-CVE-2021-22569-on-trilead-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,13 @@
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>trilead-ssh2</artifactId>
-            <version>build-217-jenkins-27</version>
+            <version>build-217-jenkins-211.vbb42cae44b18</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.kohsuke</groupId>
@@ -96,6 +102,11 @@
                     <artifactId>trilead-ssh2</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.16.1</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Appropriate autotests or explanation to why this change has no tests

