### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,5 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
 buildPlugin(useContainerAgent: true, configurations: [
-  [platform: 'linux', jdk: 17],
-  [platform: 'linux', jdk: 11],
-  [platform: 'windows', jdk: 11],
+  [platform: 'linux', jdk: 21],
+  [platform: 'windows', jdk: 17],
 ])


### PR DESCRIPTION
## Test with Java 21

Java 21 released Sep 19, 2023. We'd like to announce full support for Java 21 in early October and would like the most used plugins to be compiling and testing with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

Java 11 will be unsupported by Eclipse Temurin and some other Java providers in October 2024. We'll need to move past Java 11 by that time. It does not change the supported Java version or the byte code that is being generated.

This intentionally does not include Java 11 in the test configuration because Java 11 byte code is being generated by the Java 17 and Java 21 compilation and because Java 11 is being tested at least weekly by the plugin bill of materials.

Let's save the expense of testing Java 11 on ci.jenkins.io and rely on the existing tests (bom) of Java 11 and the Java 17 and Java 21 tests that run with Java 11 byte code.

### Submitter checklist

- [x] [JIRA issue](https://issues.jenkins.io/browse/JENKINS-71800) is well described 
- [x] Appropriate autotests or explanation to why this change has no tests
