### PR TITLE
add eddsa plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <revision>2</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/trilead-api-plugin</gitHubRepo>
-        <jenkins.version>2.401.3</jenkins.version>
+        <jenkins.version>2.426.3</jenkins.version>
         <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
     </properties>
 
@@ -73,7 +73,7 @@
       <dependencies>
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
-          <artifactId>bom-2.401.x</artifactId>
+          <artifactId>bom-2.426.x</artifactId>
           <version>2745.vc7b_fe4c876fa_</version>
           <type>pom</type>
           <scope>import</scope>
@@ -91,6 +91,11 @@
                     <groupId>com.google.code.gson</groupId>
                     <artifactId>gson</artifactId>
                 </exclusion>
+                <!-- Provided by eddsa-api plugin -->
+                <exclusion>
+                    <groupId>net.i2p.crypto</groupId>
+                    <artifactId>eddsa</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -107,6 +112,11 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>gson-api</artifactId>
+          </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>eddsa-api</artifactId>
+            <version>0.3.0-4.v84c6f0f4969e</version>
           </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
as the EdDSA library is needed by several plugins it has been split to a separate plugin.

This moves the eddsa dependency from this plugin to obtain it via the eddsa-api plugin

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Appropriate autotests or explanation to why this change has no tests

