### PR TITLE
Bump Jenkins Core to 2.462.3 latest version supporting Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <dependencyManagement>
       <dependencies>
         <dependency>
-          <groupId>=</groupId>
+          <groupId>io.jenkins.tools.bom</groupId>
           <artifactId>bom-2.462.x</artifactId>
           <version>3387.v0f2773fa_3200</version>
           <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <revision>2</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/trilead-api-plugin</gitHubRepo>
-        <jenkins.version>2.426.3</jenkins.version>
+        <jenkins.version>2.462.3</jenkins.version>
         <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
     </properties>
 
@@ -73,7 +73,7 @@
       <dependencies>
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
-          <artifactId>bom-2.426.x</artifactId>
+          <artifactId>bom-2.462.x</artifactId>
           <version>3208.vb_21177d4b_cd9</version>
           <type>pom</type>
           <scope>import</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,9 @@
     <dependencyManagement>
       <dependencies>
         <dependency>
-          <groupId>io.jenkins.tools.bom</groupId>
+          <groupId>=</groupId>
           <artifactId>bom-2.462.x</artifactId>
-          <version>3208.vb_21177d4b_cd9</version>
+          <version>3387.v0f2773fa_3200</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>


### PR DESCRIPTION
Bump Jenkins Core to the latest version that support Java 11
