### PR TITLE
fix: update to latest trilead-ssh2 module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,10 @@
           <type>pom</type>
           <scope>import</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+        </dependency>
       </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>trilead-ssh2</artifactId>
-            <version>trilead-ssh2-build-217-jenkins-17</version>
+            <version>build-217-jenkins-324.v1d9a_9f4d065e</version>
             <exclusions>
                 <!-- Provided by gson-api plugin -->
                 <exclusion>


### PR DESCRIPTION
fix: update to latest trilead-ssh2 module

At https://github.com/jenkinsci/trilead-api-plugin/pull/165 I merged a change to an old version of the library.

