### PR TITLE
Resolve upper bounds error in BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,10 +80,6 @@
           <type>pom</type>
           <scope>import</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-        </dependency>
       </dependencies>
     </dependencyManagement>
     <dependencies>
@@ -92,6 +88,11 @@
             <artifactId>trilead-ssh2</artifactId>
             <version>build-217-jenkins-324.v1d9a_9f4d065e</version>
             <exclusions>
+                <!-- Not needed at runtime -->
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
                 <!-- Provided by gson-api plugin -->
                 <exclusion>
                     <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
```
00:02:37.135  [ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.5.0:enforce (display-info) on project sample: 
00:02:37.135  [ERROR] Rule 6: org.apache.maven.enforcer.rules.dependency.RequireUpperBoundDeps failed with message:
00:02:37.135  [ERROR] Failed while enforcing RequireUpperBoundDeps. The error(s) are [
00:02:37.135  [ERROR] Require upper bound dependencies error for com.google.errorprone:error_prone_annotations:2.18.0 paths to dependency are:
00:02:37.135  [ERROR] +-io.jenkins.tools.bom:sample:4258.v34ec909e08d7
00:02:37.135  [ERROR]   +-org.jenkins-ci.plugins:jsch:0.2.16-95.v8a_0339fdcda_2
00:02:37.135  [ERROR]     +-org.jenkins-ci.plugins:trilead-api:2.191.vfdd2d67812d8 (managed) <-- org.jenkins-ci.plugins:trilead-api:2.147.vb_73cc728a_32e
00:02:37.135  [ERROR]       +-org.jenkins-ci:trilead-ssh2:build-217-jenkins-324.v1d9a_9f4d065e
00:02:37.135  [ERROR]         +-com.google.crypto.tink:tink:1.16.0
00:02:37.135  [ERROR]           +-com.google.errorprone:error_prone_annotations:2.18.0 (managed) <-- com.google.errorprone:error_prone_annotations:2.22.0
00:02:37.135  [ERROR] ]
00:02:37.135  [ERROR] -> [Help 1]
```