### PR TITLE
chore: bump Jenkins Core

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.8</version>
+    <version>1.10</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
 buildPlugin(useContainerAgent: true, configurations: [
   [platform: 'linux', jdk: 21],
-  [platform: 'windows', jdk: 17],
+  [platform: 'windows', jdk: 21],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.17</version>
+        <version>5.18</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.6</version>
+        <version>5.7</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.87</version>
+        <version>4.88</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.86</version>
+        <version>4.87</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.85</version>
+        <version>4.86</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.3</version>
+        <version>5.4</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.16</version>
+        <version>5.17</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.12</version>
+        <version>5.16</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.4</version>
+        <version>5.5</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.5</version>
+        <version>5.6</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.9</version>
+        <version>5.10</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.7</version>
+        <version>5.8</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.10</version>
+        <version>5.11</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.11</version>
+        <version>5.12</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>4545.v56392b_7ca_7b_a_</version>
+            <version>4570.v1b_c718dd3b_1e</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -80,13 +80,17 @@
           <type>pom</type>
           <scope>import</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+        </dependency>
       </dependencies>
     </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>trilead-ssh2</artifactId>
-            <version>trilead-ssh2-build-217-jenkins-17</version>
+            <version>build-217-jenkins-324.v1d9a_9f4d065e</version>
             <exclusions>
                 <!-- Provided by gson-api plugin -->
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>3722.vcc62e7311580</version>
+            <version>3761.vd922730f0fd2</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>3850.vb_c5319efa_e29</version>
+            <version>3875.v1df09947cde6</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
           <artifactId>bom-2.462.x</artifactId>
-          <version>3482.vc10d4f6da_28a_</version>
+          <version>3532.v8059503f6b_23</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>3790.va_b_a_2d26d2b_69</version>
+            <version>3814.v9563d972079a_</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>4669.v0e99c712a_30e</version>
+            <version>4710.v016f0a_07e34d</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
           <artifactId>bom-2.462.x</artifactId>
-          <version>3387.v0f2773fa_3200</version>
+          <version>3435.v238d66a_043fb_</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
           <artifactId>bom-2.462.x</artifactId>
-          <version>3559.vb_5b_81183b_d23</version>
+          <version>3613.v584fca_12cf5c</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>4770.v9a_2b_7a_9d8b_7f</version>
+            <version>4862.vc32a_71c3e731</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>4969.v6ffa_18d90c9f</version>
+            <version>5015.vb_52d36583443</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>4023.va_eeb_b_4e45f07</version>
+            <version>4051.v78dce3ce8b_d6</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
           <artifactId>bom-2.462.x</artifactId>
-          <version>3532.v8059503f6b_23</version>
+          <version>3559.vb_5b_81183b_d23</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>4948.vcf1d17350668</version>
+            <version>4969.v6ffa_18d90c9f</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>trilead-ssh2</artifactId>
-            <version>build-217-jenkins-331.v721a_1861cff6</version>
+            <version>build-217-jenkins-333.v769a_63c2340e</version>
             <exclusions>
                 <!-- Not needed at runtime -->
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>4890.vfca_82c6741a_d</version>
+            <version>4924.v6b_eb_a_79a_d9d0</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -80,10 +80,6 @@
           <type>pom</type>
           <scope>import</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-        </dependency>
       </dependencies>
     </dependencyManagement>
     <dependencies>
@@ -92,6 +88,11 @@
             <artifactId>trilead-ssh2</artifactId>
             <version>build-217-jenkins-324.v1d9a_9f4d065e</version>
             <exclusions>
+                <!-- Not needed at runtime -->
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
                 <!-- Provided by gson-api plugin -->
                 <exclusion>
                     <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.2</version>
+        <version>5.3</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
           <artifactId>bom-2.426.x</artifactId>
-          <version>3193.v330d8248d39e</version>
+          <version>3208.vb_21177d4b_cd9</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>4228.v0a_71308d905b_</version>
+            <version>4440.v39a_9eb_b_c6b_4d</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>4136.vca_c3202a_7fd1</version>
+            <version>4228.v0a_71308d905b_</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
           <artifactId>bom-2.426.x</artifactId>
-          <version>3180.vc1df4d5b_8097</version>
+          <version>3193.v330d8248d39e</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.88</version>
+        <version>5.2</version>
         <relativePath />
     </parent>
 
@@ -51,7 +51,8 @@
         <revision>2</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/trilead-api-plugin</gitHubRepo>
-        <jenkins.version>2.462.3</jenkins.version>
+        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
         <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
     </properties>
 
@@ -73,8 +74,8 @@
       <dependencies>
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
-          <artifactId>bom-2.462.x</artifactId>
-          <version>3613.v584fca_12cf5c</version>
+            <artifactId>bom-${jenkins.baseline}.x</artifactId>
+            <version>3613.v584fca_12cf5c</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.8</version>
+        <version>5.9</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>3761.vd922730f0fd2</version>
+            <version>3790.va_b_a_2d26d2b_69</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>4740.v75a_90f6fefb_7</version>
+            <version>4770.v9a_2b_7a_9d8b_7f</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>5043.v855ff4819a_0f</version>
+            <version>5054.v620b_5d2b_d5e6</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>3944.v1a_e4f8b_452db_</version>
+            <version>4023.va_eeb_b_4e45f07</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>4488.v7fe26526366e</version>
+            <version>4545.v56392b_7ca_7b_a_</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>3654.v237e4a_f2d8da_</version>
+            <version>3696.vb_b_4e2d1a_0542</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>3893.v213a_42768d35</version>
+            <version>3944.v1a_e4f8b_452db_</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
           <artifactId>bom-2.462.x</artifactId>
-          <version>3435.v238d66a_043fb_</version>
+          <version>3482.vc10d4f6da_28a_</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <revision>2</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/trilead-api-plugin</gitHubRepo>
+        <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
         <jenkins.baseline>2.479</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.1</jenkins.version>
         <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
@@ -117,7 +118,6 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>eddsa-api</artifactId>
-            <version>0.3.0-4.v84c6f0f4969e</version>
           </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>3814.v9563d972079a_</version>
+            <version>3850.vb_c5319efa_e29</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>4051.v78dce3ce8b_d6</version>
+            <version>4136.vca_c3202a_7fd1</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>4440.v39a_9eb_b_c6b_4d</version>
+            <version>4488.v7fe26526366e</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>trilead-ssh2</artifactId>
-            <version>build-217-jenkins-324.v1d9a_9f4d065e</version>
+            <version>build-217-jenkins-331.v721a_1861cff6</version>
             <exclusions>
                 <!-- Not needed at runtime -->
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <revision>2</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/trilead-api-plugin</gitHubRepo>
-        <jenkins.version>2.426.3</jenkins.version>
+        <jenkins.version>2.462.3</jenkins.version>
         <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
     </properties>
 
@@ -73,8 +73,8 @@
       <dependencies>
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
-          <artifactId>bom-2.426.x</artifactId>
-          <version>3208.vb_21177d4b_cd9</version>
+          <artifactId>bom-2.462.x</artifactId>
+          <version>3387.v0f2773fa_3200</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>3696.vb_b_4e2d1a_0542</version>
+            <version>3722.vcc62e7311580</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>4924.v6b_eb_a_79a_d9d0</version>
+            <version>4948.vcf1d17350668</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>4570.v1b_c718dd3b_1e</version>
+            <version>4628.v2b_234a_1a_20d0</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <gitHubRepo>jenkinsci/trilead-api-plugin</gitHubRepo>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
         <jenkins.baseline>2.479</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>3613.v584fca_12cf5c</version>
+            <version>3654.v237e4a_f2d8da_</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>trilead-ssh2</artifactId>
-            <version>build-217-jenkins-274.276.v58da_75159cb_7</version>
+            <version>trilead-ssh2-build-217-jenkins-17</version>
             <exclusions>
                 <!-- Provided by gson-api plugin -->
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>3875.v1df09947cde6</version>
+            <version>3893.v213a_42768d35</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>4862.vc32a_71c3e731</version>
+            <version>4890.vfca_82c6741a_d</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,128 +1,126 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>5.18</version>
-        <relativePath />
-    </parent>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>5.18</version>
+    <relativePath />
+  </parent>
 
-    <artifactId>trilead-api</artifactId>
-    <version>${revision}.${changelist}</version>
-    <packaging>hpi</packaging>
+  <artifactId>trilead-api</artifactId>
+  <version>${revision}.${changelist}</version>
+  <packaging>hpi</packaging>
 
+  <name>Trilead API Plugin</name>
+  <description>This plugin provides access to Trilead without having to bundle Trilead in Jenkins core</description>
+  <url>https://github.com/jenkinsci/trilead-api-plugin</url>
+  <licenses>
+    <license>
+      <name>The MIT license</name>
+      <url>https://opensource.org/licenses/MIT</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
 
-    <name>Trilead API Plugin</name>
-    <description>
-        This plugin provides access to Trilead without having to bundle Trilead in Jenkins core
-    </description>
-    <url>https://github.com/jenkinsci/trilead-api-plugin</url>
-    <licenses>
-        <license>
-            <name>The MIT license</name>
-            <url>https://opensource.org/licenses/MIT</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
+  <developers>
+    <developer>
+      <id>mc1arke</id>
+      <name>Michael Clarke</name>
+      <email>michael.m.clarke@gmail.com</email>
+    </developer>
+    <developer>
+      <id>kuisathaverat</id>
+      <name>Ivan Fernandez</name>
+      <email>kuisathaverat@gmail.com</email>
+    </developer>
+  </developers>
 
-    <developers>
-        <developer>
-            <id>mc1arke</id>
-            <name>Michael Clarke</name>
-            <email>michael.m.clarke@gmail.com</email>
-        </developer>
-        <developer>
-            <id>kuisathaverat</id>
-            <name>Ivan Fernandez</name>
-            <email>kuisathaverat@gmail.com</email>
-        </developer>
-    </developers>
-
-    <scm>
-        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
-        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-        <url>https://github.com/${gitHubRepo}</url>
-        <tag>${scmTag}</tag>
+  <scm>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
   </scm>
 
-    <properties>
-        <revision>2</revision>
-        <changelist>999999-SNAPSHOT</changelist>
-        <gitHubRepo>jenkinsci/trilead-api-plugin</gitHubRepo>
-        <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.479</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
-        <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
-    </properties>
+  <properties>
+    <revision>2</revision>
+    <changelist>999999-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/trilead-api-plugin</gitHubRepo>
+    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+    <jenkins.baseline>2.504</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
+    <spotless.check.skip>false</spotless.check.skip>
+  </properties>
 
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-
-    <dependencyManagement>
-      <dependencies>
-        <dependency>
-          <groupId>io.jenkins.tools.bom</groupId>
-            <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>5054.v620b_5d2b_d5e6</version>
-          <type>pom</type>
-          <scope>import</scope>
-        </dependency>
-      </dependencies>
-    </dependencyManagement>
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci</groupId>
-            <artifactId>trilead-ssh2</artifactId>
-            <version>build-217-jenkins-333.v769a_63c2340e</version>
-            <exclusions>
-                <!-- Not needed at runtime -->
-                <exclusion>
-                    <groupId>com.google.errorprone</groupId>
-                    <artifactId>error_prone_annotations</artifactId>
-                </exclusion>
-                <!-- Provided by gson-api plugin -->
-                <exclusion>
-                    <groupId>com.google.code.gson</groupId>
-                    <artifactId>gson</artifactId>
-                </exclusion>
-                <!-- Provided by eddsa-api plugin -->
-                <exclusion>
-                    <groupId>net.i2p.crypto</groupId>
-                    <artifactId>eddsa</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.kohsuke</groupId>
-            <artifactId>trilead-putty-extension</artifactId>
-            <version>1.2</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jenkins-ci</groupId>
-                    <artifactId>trilead-ssh2</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.jenkins.plugins</groupId>
-            <artifactId>gson-api</artifactId>
-          </dependency>
-        <dependency>
-            <groupId>io.jenkins.plugins</groupId>
-            <artifactId>eddsa-api</artifactId>
-          </dependency>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+        <version>5054.v620b_5d2b_d5e6</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>eddsa-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>gson-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>trilead-ssh2</artifactId>
+      <version>build-217-jenkins-333.v769a_63c2340e</version>
+      <exclusions>
+        <!-- Provided by gson-api plugin -->
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+        </exclusion>
+        <!-- Not needed at runtime -->
+        <exclusion>
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+        <!-- Provided by eddsa-api plugin -->
+        <exclusion>
+          <groupId>net.i2p.crypto</groupId>
+          <artifactId>eddsa</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>trilead-putty-extension</artifactId>
+      <version>1.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci</groupId>
+          <artifactId>trilead-ssh2</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>4710.v016f0a_07e34d</version>
+            <version>4740.v75a_90f6fefb_7</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>5015.vb_52d36583443</version>
+            <version>5043.v855ff4819a_0f</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>4628.v2b_234a_1a_20d0</version>
+            <version>4669.v0e99c712a_30e</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>


### PR DESCRIPTION
This pull request updates the plugin's dependencies, build configurations, and metadata to align with newer Jenkins baselines and best practices. Key changes include updating Maven and Jenkins configurations, refining dependencies, and adjusting build scripts for better compatibility and maintainability.

### Dependency and Configuration Updates:
- Updated the Maven parent plugin version from `4.88` to `5.18` in `pom.xml` for compatibility with newer Jenkins features.
- Replaced `jenkins.version` with a new `jenkins.baseline` property set to `2.504` and updated dependency management to use `bom-2.504.x` with version `5054.v620b_5d2b_d5e6`.
- Added new dependencies for `eddsa-api` and `gson-api` plugins while excluding unnecessary runtime dependencies like `error_prone_annotations`.
- Restored `repositories` and `pluginRepositories` sections in `pom.xml` for accessing Jenkins public repositories.

### Build Script Adjustments:
- Updated the Windows build configuration in `Jenkinsfile` to use JDK 21 instead of JDK 17 for consistency across platforms.

### Minor Improvements:
- Updated the Maven extension version from `1.8` to `1.10` in `.mvn/extensions.xml` for improved build tooling.
- Reformatted the `description` and `scm` sections in `pom.xml` for better readability and alignment with XML standards. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L8-R17) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L46-R92)

