### PR TITLE
Rely on repository permissions updater for developer list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,19 +24,6 @@
     </license>
   </licenses>
 
-  <developers>
-    <developer>
-      <id>mc1arke</id>
-      <name>Michael Clarke</name>
-      <email>michael.m.clarke@gmail.com</email>
-    </developer>
-    <developer>
-      <id>kuisathaverat</id>
-      <name>Ivan Fernandez</name>
-      <email>kuisathaverat@gmail.com</email>
-    </developer>
-  </developers>
-
   <scm>
     <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>


### PR DESCRIPTION
## Rely on repository permissions updater for developer list

The `developers` section of the pom file is not the authoritative list of plugin maintainers.  That list is provided by the repository permissions updater at https://github.com/jenkins-infra/repository-permissions-updater

No automated tests because this change is internal only

### Submitter checklist

- [x] Appropriate autotests or explanation to why this change has no tests

