### PR TITLE
Use release drafter 7.1.1 syntax in config file

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,1 +1,1 @@
-_extends: .github
+_extends: github:jenkinsci/.github:/.github/release-drafter.yml


### PR DESCRIPTION
## Use release drafter 7.1.1 syntax in config file

Match with updated version of maven-cd action.

No automated tests possible.  No Jira ticket

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Appropriate autotests or explanation to why this change has no tests

